### PR TITLE
finish fixing the bug

### DIFF
--- a/src/containers/CourseInfoContainer.js
+++ b/src/containers/CourseInfoContainer.js
@@ -159,7 +159,7 @@ function CourseInfoContainer ({code}){
                 return;
             }
             // determine init state
-            if (course_table.courses.includes(code)){
+            if (course_table && course_table.courses.includes(code)){
                 setSelected(true);
             } else {
                 setSelected(false);


### PR DESCRIPTION
Solving bug in issue #67 .

When user in guest mode and his course_table expired,
`fetchCourseTable` defined in `src/actions` will return `null`.

Then, `getInitState` init function will crash when course_table is null.
Thus, the loading state will not stop because of this.