### PR TITLE
change key version

### DIFF
--- a/src/constant.ts
+++ b/src/constant.ts
@@ -1,7 +1,7 @@
 import type { Interval } from "types/course";
 
 export const NCN_COURSE_TABLE_LOCAL_STORAGE_KEY =
-  "NTU_CourseNeo_Course_Table_Key";
+  "NTU_CourseNeo_Course_Table_Key_v2";
 export const intervals: Interval[] = [
   "0",
   "1",


### PR DESCRIPTION
## Solve client-side error like this:
<img width="947" alt="截圖 2022-08-25 下午4 53 47" src="https://user-images.githubusercontent.com/71842426/186620916-32ff721e-61e6-418c-a3af-987317c2ecbb.png">

## Reason: 
Since the previous PR add course-table-id encryption, the string format stored at localStorage changed.
Ex:
```
// ---- prev ----
// store
const id = uuid()
localStorage.setItem("NTU_CourseNeo_Course_Table_Key", id)
// retrieve
const id = localStorage.getItem("NTU_CourseNeo_Course_Table_Key")

// ---- now ----
// store
const id = uuid()
localStorage.setItem("NTU_CourseNeo_Course_Table_Key", encryptId(id))
// retrieve
const id = decryptId(localStorage.getItem("NTU_CourseNeo_Course_Table_Key"))
```
However, some clients' local storage still stores the string with the old version's format. Therefore, the error is thrown when decryption.

## Solution:

Use versioning. Replace `"NTU_CourseNeo_Course_Table_Key"` with `"NTU_CourseNeo_Course_Table_Key_v2"` as our course table key at localStorage to make sure our code will always look for value with "new format" instead of accidentally retrieving "old format".
